### PR TITLE
feat(lock): explicitly requiring pubkey to lock PAL for

### DIFF
--- a/src/actions/lockup.ts
+++ b/src/actions/lockup.ts
@@ -36,10 +36,12 @@ import {
  */
 export function getLockupInstruction({
   lockupAuthority,
+  lockupForPubkey,
   lockupAccount,
   amount,
 }: {
   lockupAuthority: PublicKey;
+  lockupForPubkey: PublicKey;
   lockupAccount: PublicKey;
   amount: number;
 }): TransactionInstruction {
@@ -49,7 +51,7 @@ export function getLockupInstruction({
   // Serialize instruction data
   const data = serializeInstructionData(
     instruction.discriminant.value, // Discriminator for Lockup instruction
-    lockupAuthority,
+    lockupForPubkey,
     BigInt(amount)
   );
 
@@ -179,10 +181,12 @@ export function getLockupInstruction({
 export async function makeLockupTransaction(
   account: PublicKey | string,
   amount: number,
-  connection: Connection
+  connection: Connection,
+  lockupForPubkey: PublicKey | string
 ): Promise<VersionedTransaction> {
   // Convert string to PublicKey if needed
   const pubkey = typeof account === 'string' ? new PublicKey(account) : account;
+  const lockupPubkey = typeof lockupForPubkey === 'string' ? new PublicKey(lockupForPubkey) : lockupForPubkey;
 
   if (!pubkey) throw new Error("Account is required");
   console.log("wallet pubkey:", pubkey.toBase58());
@@ -202,6 +206,7 @@ export async function makeLockupTransaction(
   // Get lockup instruction
   const lockupIx = getLockupInstruction({
     lockupAuthority: pubkey,
+    lockupForPubkey: lockupPubkey,
     lockupAccount: lockupAccount.publicKey,
     amount,
   });

--- a/src/functional/index.ts
+++ b/src/functional/index.ts
@@ -21,12 +21,14 @@ export interface WalletAdapter {
  * 
  * @param wallet Wallet adapter interface with publicKey and sendTransaction
  * @param connection Solana connection
+ * @param lockupForPubkey The pubkey to lock PAL for
  * @param amount Amount of tokens to lock (in tokens, not raw units)
  * @returns Object containing signature and confirm function
  */
 export async function lockTokens(
   wallet: WalletAdapter,
   connection: Connection,
+  lockupForPubkey: PublicKey | string,
   amount: number
 ) {
   if (!wallet.publicKey) {
@@ -41,7 +43,8 @@ export async function lockTokens(
     const transaction = await makeLockupTransaction(
       wallet.publicKey,
       rawAmount,
-      connection
+      connection,
+      lockupForPubkey
     );
     
     // Send the transaction through the wallet adapter

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -45,24 +45,19 @@ export function collectHolderRewardsSeeds(tokenAccountAddress: PublicKey): Buffe
 /**
  * Serializes instruction data with discriminator, metadata, and amount
  * @param discriminator The instruction discriminator
- * @param authority The authority public key
+ * @param lockupForPubkey The pubkey to lock PAL for
  * @param amount The amount as bigint
  * @returns Buffer containing serialized instruction data
  */
 export function serializeInstructionData(
   discriminator: number,
-  authority: PublicKey,
+  lockupForPubkey: PublicKey,
   amount: bigint
 ): Buffer {
   // Create discriminator buffer
   const discriminatorBuffer = Buffer.from([discriminator]);
   
-  // Authority buffer (as metadata)
-  // TODO: Right now, the tx sender who the tokens are being
-  // locked on behalf of is constrained to being the authority
-  // that's signing this transaction.
-  // Determine if we need more flexibility here.
-  const metadata = authority.toBuffer();
+  const metadata = lockupForPubkey.toBuffer();
   
   // Convert amount to 8-byte little-endian buffer
   const amountBuffer = Buffer.alloc(8);


### PR DESCRIPTION
`lockTokens()` should allow whoever is locking PAL to do so for any pubkey, not just their own pubkey (this is important, e.g., when users want to lock tokens through the web app using a hot wallet but will be sending transasctions through a programmatic wallet.